### PR TITLE
Fix undefined dtype variable in memory_buffer

### DIFF
--- a/verl/utils/memory_buffer.py
+++ b/verl/utils/memory_buffer.py
@@ -103,8 +103,9 @@ def build_memory_reference_from_module(module: torch.nn.Module, memory_buffers: 
     for name, param in sorted(module.named_parameters()):
         memory_buffer = memory_buffers[param.dtype]
         buffer = memory_buffer.get(shape=param.shape, start_index=start_index[param.dtype])
-        # need to increment start_index
-        start_index[param.dtype] += calc_padded_numel(param.shape, dtype)
+        # need to increment start_index. Make sure to use param.dtype
+        # since each dtype has its own buffer alignment.
+        start_index[param.dtype] += calc_padded_numel(param.shape, param.dtype)
         if maintain_weight:
             buffer.copy_(param.data)
         param.data = buffer


### PR DESCRIPTION
## Summary
- fix typo in `build_memory_reference_from_module`
- clarify comment about updating `start_index`

## Testing
- `ruff check verl/utils/memory_buffer.py --fix`
- `pre-commit run --files verl/utils/memory_buffer.py` *(fails: command not found)*
- `pytest -k memory_buffer -q` *(fails: command not found)*